### PR TITLE
Forming paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,14 @@ const GW_MAX_LAT = new BN(2 ** 23).subn(1);
 const GW_MAX_LON = new BN(2 ** 24).subn(1);
 const GW_INCRE = new BN("21457672119140625");
 
+const DIR_NORTH = new BN("00", 2);
+const DIR_SOUTH = new BN("01", 2);
+const DIR_EAST = new BN("10", 2);
+const DIR_WEST = new BN("11", 2);
+
+const INNER_PATH_MASK = new BN(1).shln(256 - 8).subn(1);
+const MAX_PATH_LEN = 256 / 8 / 2;
+
 function from_gps(lon, lat) {
   if (lat < -90 || lat >= 90) {
     throw new Error("Latitude must be between -90 and <90");
@@ -73,6 +81,92 @@ function make_gw_coord(x, y) {
   return new BN(x).shln(32).or(new BN(y));
 }
 
+// Make a rectangular path between two coordinates
+function make_rect_path(sourceCoord, destCoord) {
+  _validate_coord(sourceCoord);
+  _validate_coord(destCoord);
+
+  let x_s = get_x(sourceCoord);
+  let y_s = get_y(sourceCoord);
+
+  let x_d = get_x(destCoord);
+  let y_d = get_y(destCoord);
+
+  let paths = [];
+  let path = new BN(0);
+
+  function _append(direction) {
+    if (path_length(path) >= MAX_PATH_LEN) {
+      // Add to new path
+      paths.push(path);
+      path = new BN(0);
+    }
+
+    path = append_to_path(path, direction);
+  }
+
+  for (let y_offset = 0; y_offset <= Math.abs(y_d - y_s); y_offset++) {
+    for (let x_offset = 0; x_offset < Math.abs(x_d - x_s); x_offset++) {
+      // Each column
+      let dir_even = x_d > x_s ? DIR_EAST : DIR_WEST;
+      let dir_odd = x_d > x_s ? DIR_WEST : DIR_EAST;
+      let direction_x = y_offset % 2 == 0 ? dir_even : dir_odd;
+      _append(direction_x);
+    }
+
+    // Each row
+    if (y_offset < Math.abs(y_d - y_s)) {
+      let direction_y = y_d > y_s ? DIR_NORTH : DIR_SOUTH;
+      _append(direction_y);
+    }
+  }
+
+  paths.push(path);
+
+  return paths;
+}
+
+function append_to_path(path, direction) {
+  if (!BN.isBN(direction)) {
+    throw new Error("Direction should be a BN");
+  }
+  if (direction > 3) {
+    throw new Error("Direction is out of range");
+  }
+  if (!BN.isBN(path)) {
+    throw new Error("Path should be a BN");
+  }
+
+  let length = path_length(path);
+  if (length >= MAX_PATH_LEN) {
+    throw new Error("Path is at maximum length");
+  }
+
+  let newLength = length.addn(1).shln(256 - 8);
+
+  let newPath = newLength.or(
+    path.and(INNER_PATH_MASK).or(direction.shln(length * 2))
+  );
+  return newPath;
+}
+
+function path_length(path) {
+  return path.shrn(256 - 8);
+}
+
+function _validate_coord(coord) {
+  if (!BN.isBN(coord)) {
+    throw new Error("GeoWebCoordinate should be a BN");
+  }
+
+  if (get_x(coord).gt(GW_MAX_LON)) {
+    throw new Error("Longitude is out of bounds");
+  }
+  if (get_y(coord).gt(GW_MAX_LAT)) {
+    throw new Error("Latitude is out of bounds");
+  }
+}
+
 function _to_gps_decimal(c) {
   // Round to 10 digits from 21
   // Convert to decimal
@@ -85,6 +179,8 @@ var GeoWebCoordinate = {
   make_gw_coord: make_gw_coord,
   get_x: get_x,
   get_y: get_y,
+  append_to_path: append_to_path,
+  make_rect_path: make_rect_path,
 };
 
 module.exports = GeoWebCoordinate;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const DIR_EAST = new BN("10", 2);
 const DIR_WEST = new BN("11", 2);
 
 const INNER_PATH_MASK = new BN(1).shln(256 - 8).subn(1);
-const MAX_PATH_LEN = 256 / 8 / 2;
+const MAX_PATH_LEN = (256 - 8) / 2;
 
 function from_gps(lon, lat) {
   if (lat < -90 || lat >= 90) {
@@ -121,7 +121,9 @@ function make_rect_path(sourceCoord, destCoord) {
     }
   }
 
-  paths.push(path);
+  if (path_length(path) > 0) {
+    paths.push(path);
+  }
 
   return paths;
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -2,6 +2,10 @@ const GeoWebCoordinate = require("../");
 const test = require("assert");
 const BN = require("bn.js");
 
+function makePathPrefix(length) {
+  return new BN(length).shln(256 - 8);
+}
+
 exports.testFromGPSBasic = function (test) {
   let lon = 110.0;
   let lat = 38.0;
@@ -233,6 +237,109 @@ exports.testToGPSLatOutOfBounds = function (test) {
 
   test.throws(() => GeoWebCoordinate.to_gps(gwCoord));
 
+  test.done();
+};
+
+exports.testAppendPathEmpty = function (test) {
+  let path = new BN(0);
+  let direction = new BN("10", 2);
+
+  let newPath = GeoWebCoordinate.append_to_path(path, direction);
+
+  test.equal(
+    newPath.toString(2),
+    "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010"
+  );
+  test.done();
+};
+
+exports.testAppendPathMultiple = function (test) {
+  let newPath = GeoWebCoordinate.append_to_path(new BN(0), new BN("10", 2));
+  newPath = GeoWebCoordinate.append_to_path(newPath, new BN("00", 2));
+  newPath = GeoWebCoordinate.append_to_path(newPath, new BN("01", 2));
+  newPath = GeoWebCoordinate.append_to_path(newPath, new BN("01", 2));
+  newPath = GeoWebCoordinate.append_to_path(newPath, new BN("11", 2));
+
+  test.equal(
+    newPath.toString(2),
+    "10100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001101010010"
+  );
+  test.done();
+};
+
+exports.testAppendPathTooLong = function (test) {
+  test.throws(() =>
+    GeoWebCoordinate.append_to_path(new BN(125).shln(248), new BN("10", 2))
+  );
+  test.done();
+};
+
+exports.testMakeRectPathSingle = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  test.equal(paths[0].toString(2), new BN(0).toString(2));
+  test.done();
+};
+
+exports.testMakeRectPathSquare1 = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("2", "2");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(8).or(new BN("1010001111001010", 2));
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectPathSquare2 = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("2", "2");
+  let destCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(8).or(new BN("1111011010011111", 2));
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectPathSquare3 = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "2");
+  let destCoord = GeoWebCoordinate.make_gw_coord("2", "0");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(8).or(new BN("1010011111011010", 2));
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectPathSquare4 = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("2", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("0", "2");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(8).or(new BN("1111001010001111", 2));
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectPathRect1 = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("2", "3");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(11).or(new BN("1111001010001111001010", 2));
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectPathRect2 = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("3", "2");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(11).or(new BN("1010100011111100101010", 2));
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
   test.done();
 };
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -279,7 +279,7 @@ exports.testMakeRectPathSingle = function (test) {
   let destCoord = GeoWebCoordinate.make_gw_coord("0", "0");
 
   let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
-  test.equal(paths[0].toString(2), new BN(0).toString(2));
+  test.equal(paths.length, 0);
   test.done();
 };
 
@@ -289,6 +289,7 @@ exports.testMakeRectPathSquare1 = function (test) {
 
   let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
   let expectedPath = makePathPrefix(8).or(new BN("1010001111001010", 2));
+  test.equal(paths.length, 1);
   test.equal(paths[0].toString(2), expectedPath.toString(2));
   test.done();
 };
@@ -299,6 +300,7 @@ exports.testMakeRectPathSquare2 = function (test) {
 
   let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
   let expectedPath = makePathPrefix(8).or(new BN("1111011010011111", 2));
+  test.equal(paths.length, 1);
   test.equal(paths[0].toString(2), expectedPath.toString(2));
   test.done();
 };
@@ -309,6 +311,7 @@ exports.testMakeRectPathSquare3 = function (test) {
 
   let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
   let expectedPath = makePathPrefix(8).or(new BN("1010011111011010", 2));
+  test.equal(paths.length, 1);
   test.equal(paths[0].toString(2), expectedPath.toString(2));
   test.done();
 };
@@ -319,6 +322,7 @@ exports.testMakeRectPathSquare4 = function (test) {
 
   let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
   let expectedPath = makePathPrefix(8).or(new BN("1111001010001111", 2));
+  test.equal(paths.length, 1);
   test.equal(paths[0].toString(2), expectedPath.toString(2));
   test.done();
 };
@@ -329,6 +333,7 @@ exports.testMakeRectPathRect1 = function (test) {
 
   let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
   let expectedPath = makePathPrefix(11).or(new BN("1111001010001111001010", 2));
+  test.equal(paths.length, 1);
   test.equal(paths[0].toString(2), expectedPath.toString(2));
   test.done();
 };
@@ -339,7 +344,63 @@ exports.testMakeRectPathRect2 = function (test) {
 
   let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
   let expectedPath = makePathPrefix(11).or(new BN("1010100011111100101010", 2));
+  test.equal(paths.length, 1);
   test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectEastLine = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("2", "0");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(2).or(new BN("1010", 2));
+  test.equal(paths.length, 1);
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectWestLine = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("2", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(2).or(new BN("1111", 2));
+  test.equal(paths.length, 1);
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectNorthLine = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("0", "2");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(2).or(new BN("0000", 2));
+  test.equal(paths.length, 1);
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeRectSouthLine = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "2");
+  let destCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  let expectedPath = makePathPrefix(2).or(new BN("0101", 2));
+  test.equal(paths.length, 1);
+  test.equal(paths[0].toString(2), expectedPath.toString(2));
+  test.done();
+};
+
+exports.testMakeLongPath = function (test) {
+  let sourceCoord = GeoWebCoordinate.make_gw_coord("0", "0");
+  let destCoord = GeoWebCoordinate.make_gw_coord("0", "200");
+
+  let paths = GeoWebCoordinate.make_rect_path(sourceCoord, destCoord);
+  test.equal(paths.length, 2);
+  test.equal(paths[0].toString(2), makePathPrefix(124).toString(2));
+  test.equal(paths[1].toString(2), makePathPrefix(76).toString(2));
   test.done();
 };
 


### PR DESCRIPTION
Add:
- `append_to_path`
- `make_rect_path`

Allows creating a path from a rectangle represented from two coordinates that are opposite corners.